### PR TITLE
remove next and prev from async_objects.md

### DIFF
--- a/docs/documentation/get_it/async_objects.md
+++ b/docs/documentation/get_it/async_objects.md
@@ -1,11 +1,5 @@
 ---
 title: Async Objects
-prev:
-  text: 'Object Registration'
-  link: '/documentation/get_it/object_registration'
-next:
-  text: 'Scopes'
-  link: '/documentation/get_it/scopes'
 ---
 
 # Async Objects


### PR DESCRIPTION
Without specifying them, the next and prev links at the bottom of the page are put correctly as Scopes and Multiple Registrations. The previous manual links for Object Registration and Scopes are out of order.